### PR TITLE
Add new games page

### DIFF
--- a/packages/pages/games.yaml
+++ b/packages/pages/games.yaml
@@ -18,12 +18,12 @@ lvgl_page_manager:
 substitutions:
   GAMES_FPS: "30"                      # Target frame rate (1-240)
 
-# External component from games-esphome repository
-external_components:
-  - source: https://github.com/stuartparmenter/games-esphome@main
-
 esp32_ble:
   id: ble
+  
+# External component from games-esphome repository
+external_components:
+  - source: github://stuartparmenter/games-esphome@main
 
 ble_gamepad:
   id: gamepad


### PR DESCRIPTION
This adds a new page that uses my new https://github.com/stuartparmenter/games-esphome repo for playing multiple games.

BLE + Web server end up using too much ram, so I may need to end up turning off web_server on all the psram devices before I actually merge this.