### PR TITLE
Remove hub75-esphome now that we can use built-in esphome hub75 component

### DIFF
--- a/packages/controllers/adafruit-matrix-portal-s3.yaml
+++ b/packages/controllers/adafruit-matrix-portal-s3.yaml
@@ -22,9 +22,6 @@ psram:
   mode: quad
   speed: 80MHz
 
-external_components:
-  - source: github://stuartparmenter/hub75-esphome@main
-
 display:
   - platform: hub75
     id: matrix

--- a/packages/controllers/apollo-automation-m1-rev4.yaml
+++ b/packages/controllers/apollo-automation-m1-rev4.yaml
@@ -17,9 +17,6 @@ esp32:
     sdkconfig_options:
       CONFIG_ESP32S3_DATA_CACHE_LINE_64B: y
 
-external_components:
-  - source: github://stuartparmenter/hub75-esphome@main
-
 display:
   - platform: hub75
     id: matrix

--- a/packages/controllers/apollo-automation-m1-rev6.yaml
+++ b/packages/controllers/apollo-automation-m1-rev6.yaml
@@ -48,9 +48,6 @@ microphone:
     i2s_mode: primary
     i2s_audio_id: i2s_mic_bus
 
-external_components:
-  - source: github://stuartparmenter/hub75-esphome@main
-
 display:
   - platform: hub75
     id: matrix


### PR DESCRIPTION
This requires esphome 2025.12+ and won't pass checks until it is out