### PR TITLE
Bump esphome minimum to 2025.12.3

### DIFF
--- a/packages/common/esphome-version.yaml
+++ b/packages/common/esphome-version.yaml
@@ -3,4 +3,4 @@
 
 # Enforce minimum ESPHome version
 esphome:
-  min_version: 2025.12.0
+  min_version: 2025.12.3

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "esphome"
-version = "2025.12.0"
+version = "2025.12.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aioesphomeapi" },
@@ -583,9 +583,9 @@ dependencies = [
     { name = "voluptuous" },
     { name = "zeroconf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/06/7fe360fdb3a1550233e758846892c523e49c7b72c8ede43e7c3b5d56503f/esphome-2025.12.0.tar.gz", hash = "sha256:9911c8dd44c7f86174ff0820b1f6f8ddc1424d0bfa3887486b8c0f680351abad", size = 3570449, upload-time = "2025-12-16T23:57:57.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c6/4fade03f4fc9167313d56d4608c0ea6bb3bce5e0a46f18366eb588f1b616/esphome-2025.12.3.tar.gz", hash = "sha256:7b362b2e36c1cfe7c5c8721671073b590b9c401e535dbba673359bbb32d491ec", size = 3571145, upload-time = "2025-12-30T14:32:09.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/68/b24d9bdf072a1541ab00d684946a2dcebb4387444fa83f4adfb412a5637e/esphome-2025.12.0-py3-none-any.whl", hash = "sha256:4f0259a3bb391d653febc1b9b177fd8602157bf0c44542973f786770f01cee0d", size = 5167596, upload-time = "2025-12-16T23:57:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/79/ea8f4bd8939dedb36b7e476eee8da5dee4aa81e8dc5c8c2ab5dea024a215/esphome-2025.12.3-py3-none-any.whl", hash = "sha256:0b22e927de581d5eb5711283e365e837345c4f50e3dcd3c74aadbcac1e906080", size = 5168726, upload-time = "2025-12-30T14:32:07.394Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
2025.12.10 - 2025.12.2 broke the MSR-2 radar page but was fixed in 2025.12.3 so bumping minimum version