### PR TITLE
Add power toggle button using GPIO0 boot button for Apollo M1

### DIFF
--- a/packages/controllers/apollo-automation-m1-rev4.yaml
+++ b/packages/controllers/apollo-automation-m1-rev4.yaml
@@ -36,6 +36,24 @@ display:
     auto_clear_enabled: false
     update_interval: never
 
+# Boot button (GPIO0) as power toggle
+binary_sensor:
+  - platform: gpio
+    id: power_button
+    internal: true
+    pin:
+      number: GPIO0
+      mode:
+        input: true
+        pullup: true
+      inverted: true
+    filters:
+      - delayed_on: 10ms
+      - delayed_off: 10ms
+    on_click:
+      then:
+        - switch.toggle: power
+
 lvgl:
   buffer_size: 100%
   displays:

--- a/packages/controllers/apollo-automation-m1-rev6.yaml
+++ b/packages/controllers/apollo-automation-m1-rev6.yaml
@@ -80,6 +80,24 @@ switch:
     turn_off_action:
       - microphone.mute: m1_mic
 
+# Boot button (GPIO0) as power toggle
+binary_sensor:
+  - platform: gpio
+    id: power_button
+    internal: true
+    pin:
+      number: GPIO0
+      mode:
+        input: true
+        pullup: true
+      inverted: true
+    filters:
+      - delayed_on: 10ms
+      - delayed_off: 10ms
+    on_click:
+      then:
+        - switch.toggle: power
+
 lvgl:
   buffer_size: 100%
   displays:


### PR DESCRIPTION
Adds a binary sensor on GPIO0 (boot button) that toggles the power
switch when clicked. This allows physical control of the display
power on Apollo Automation M1 Rev4 and Rev6 controllers.

The button is marked internal so it is not exposed to Home Assistant.