### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: ESPHome ${{ matrix.esphome-version }}
-        uses: esphome/build-action@76cd6898550762b189215bbe6e50e29080fd2c33 # v7
+        uses: esphome/build-action@f0a331817f5535854a10a42621b6a8b7ebe95c4c # v7.2.0
         with:
           yaml-file: ${{ matrix.file }}.yaml
           version: ${{ matrix.esphome-version }}
       - name: ESPHome ${{ matrix.esphome-version }} Factory
-        uses: esphome/build-action@76cd6898550762b189215bbe6e50e29080fd2c33 # v7
+        uses: esphome/build-action@f0a331817f5535854a10a42621b6a8b7ebe95c4c # v7.2.0
         with:
           yaml-file: ${{ matrix.file }}.factory.yaml
           version: ${{ matrix.esphome-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,14 @@ jobs:
           - dev
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: ESPHome ${{ matrix.esphome-version }}
-        uses: esphome/build-action@v7
+        uses: esphome/build-action@76cd6898550762b189215bbe6e50e29080fd2c33 # v7
         with:
           yaml-file: ${{ matrix.file }}.yaml
           version: ${{ matrix.esphome-version }}
       - name: ESPHome ${{ matrix.esphome-version }} Factory
-        uses: esphome/build-action@v7
+        uses: esphome/build-action@76cd6898550762b189215bbe6e50e29080fd2c33 # v7
         with:
           yaml-file: ${{ matrix.file }}.factory.yaml
           version: ${{ matrix.esphome-version }}

--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         file: [apollo-automation-m1-rev4, apollo-automation-m1-rev6, adafruit-matrix-portal-s3]
-    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/build.yml@e7eee2a828517c042794a831f75310959fbf2a16 # 2025.10.0
     with:
       #### Modify below here to match your project ####
       files: ${{ matrix.file }}.factory.yaml
@@ -27,7 +27,7 @@ jobs:
 
   upload-to-release:
     name: Upload to Release
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@e7eee2a828517c042794a831f75310959fbf2a16 # 2025.10.0
     needs:
       - build-firmware
     with:

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -30,25 +30,25 @@ jobs:
       contents: read
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - run: mkdir -p output/firmware
 
       - name: Build
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1
         with:
           source: ./static
           destination: ./output
 
       - name: Fetch firmware files
-        uses: robinraju/release-downloader@v1
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1
         with:
           latest: true
           fileName: '*'
           out-file-path: output/firmware
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: output
           retention-days: 1
@@ -67,8 +67,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,12 +15,12 @@ jobs:
     environment: release-drafter
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         id: drafter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
 
@@ -29,7 +29,7 @@ jobs:
           sed -i 's/^version = .*/version = "${{ steps.drafter.outputs.resolved_version }}"/g' pyproject.toml
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Regenerate lockfile
         run: uv lock


### PR DESCRIPTION
## Summary
- Replaces all mutable tag references (`@v6`, `@v7`, `@2025.10.0`, etc.) with immutable commit SHAs across all 4 workflow files
- Original version tags preserved as inline comments for readability
- Mitigates supply chain attacks where a compromised upstream could replace a tag with malicious code

## Actions pinned
| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v6 | `de0fac2e` |
| `actions/jekyll-build-pages` | v1 | `44a6e6be` |
| `actions/upload-pages-artifact` | v4 | `7b1f4a76` |
| `actions/configure-pages` | v5 | `983d7736` |
| `actions/deploy-pages` | v4 | `d6db9016` |
| `robinraju/release-downloader` | v1 | `daf26c55` |
| `esphome/build-action` | v7 | `76cd6898` |
| `esphome/workflows` | 2025.10.0 | `e7eee2a8` |
| `release-drafter/release-drafter` | v6 | `6a93d829` |
| `astral-sh/setup-uv` | v7 | `37802adc` |

## Test plan
- [ ] CI workflow runs successfully
- [ ] Publish Pages workflow runs on next push to main