### PR TITLE
Pin lvgl-page-manager to v0.2.0

### DIFF
--- a/packages/common/utils.yaml
+++ b/packages/common/utils.yaml
@@ -7,7 +7,7 @@ time:
     id: ha_time
 
 external_components:
-  - source: github://stuartparmenter/lvgl-page-manager@main
+  - source: github://stuartparmenter/lvgl-page-manager@v0.2.0
     components: [lvgl_page_manager]
 
 lvgl_page_manager:


### PR DESCRIPTION
## Summary

Pin the `lvgl-page-manager` external component in `packages/common/utils.yaml` from `@main` to the freshly-cut `@v0.2.0` tag.

## Why

`v0.2.0` captures the current `lvgl-page-manager` `main` state (commit `903954b`, "esphome 2025.11 changes action play api") — the last release compatible with LVGL 8.x / ESPHome <2026.4.0.

An upstream LVGL 9.5 + ESPHome 2026.4.0 port is queued at stuartparmenter/lvgl-page-manager#1 and has not merged yet. Without this pin, the moment that PR lands on \`main\`, every existing hub75-studio user pulling \`packages/common/utils.yaml\` would auto-upgrade to a breaking-change version without warning. Pinning to a tag avoids the silent break.

## What changes

One line in \`packages/common/utils.yaml\`:

\`\`\`diff
 external_components:
-  - source: github://stuartparmenter/lvgl-page-manager@main
+  - source: github://stuartparmenter/lvgl-page-manager@v0.2.0
     components: [lvgl_page_manager]
\`\`\`

## Follow-up

Once the LVGL 9.5 / ESPHome 2026.4.0 port lands on \`lvgl-page-manager\` main and gets a new tag (likely \`v0.3.0\`), a subsequent PR will bump this pin alongside the corresponding hub75-studio ESPHome 2026.4.0 compatibility fixes.

## Test plan

- [ ] Confirm \`esphome config\` still resolves cleanly against a user yaml that imports this package
- [ ] Confirm the factory yamls (\`apollo-automation-m1-rev6.factory.yaml\` etc.) still build end-to-end