### PR TITLE
Bump components to LVGL 9.5 / ESPHome 2026.4.0 releases

### DIFF
--- a/packages/common/ddp.yaml
+++ b/packages/common/ddp.yaml
@@ -11,7 +11,7 @@
 #   device_id: Device ID for WebSocket identification
 
 external_components:
-  - source: github://stuartparmenter/ddp-esphome@v0.7.5
+  - source: github://stuartparmenter/ddp-esphome@v0.8.0
 
 # DDP Canvas Binding
 ddp:

--- a/packages/common/esphome-version.yaml
+++ b/packages/common/esphome-version.yaml
@@ -3,4 +3,4 @@
 
 # Enforce minimum ESPHome version
 esphome:
-  min_version: 2026.1.0
+  min_version: 2026.4.0

--- a/packages/common/utils.yaml
+++ b/packages/common/utils.yaml
@@ -7,7 +7,7 @@ time:
     id: ha_time
 
 external_components:
-  - source: github://stuartparmenter/lvgl-page-manager@v0.2.0
+  - source: github://stuartparmenter/lvgl-page-manager@v0.3.0
     components: [lvgl_page_manager]
 
 lvgl_page_manager:

--- a/packages/controllers/adafruit-matrix-portal-s3.yaml
+++ b/packages/controllers/adafruit-matrix-portal-s3.yaml
@@ -280,6 +280,7 @@ light:
     id: status_led
 
 lvgl:
+  byte_order: little_endian
   buffer_size: 100%
   displays:
     - matrix

--- a/packages/controllers/apollo-automation-m1-rev4.yaml
+++ b/packages/controllers/apollo-automation-m1-rev4.yaml
@@ -55,6 +55,7 @@ binary_sensor:
         - switch.toggle: power
 
 lvgl:
+  byte_order: little_endian
   buffer_size: 100%
   displays:
     - matrix

--- a/packages/controllers/apollo-automation-m1-rev6.yaml
+++ b/packages/controllers/apollo-automation-m1-rev6.yaml
@@ -99,6 +99,7 @@ binary_sensor:
         - switch.toggle: power
 
 lvgl:
+  byte_order: little_endian
   buffer_size: 100%
   displays:
     - matrix

--- a/packages/controllers/esp32-trinity.yaml
+++ b/packages/controllers/esp32-trinity.yaml
@@ -35,6 +35,7 @@ display:
     update_interval: never
 
 lvgl:
+  byte_order: little_endian
   buffer_size: 100%
   displays:
     - matrix

--- a/packages/pages/audio-spectrum.yaml
+++ b/packages/pages/audio-spectrum.yaml
@@ -14,7 +14,7 @@ lvgl_page_manager:
       friendly_name: "${page_friendly_name}"
 
 external_components:
-  - source: github://stuartparmenter/lvgl-canvas-fx@v0.3.3
+  - source: github://stuartparmenter/lvgl-canvas-fx@v0.4.0
 
 # ---- Microphone Configuration ----
 # Hardware: I²S digital microphone

--- a/packages/pages/fx.yaml
+++ b/packages/pages/fx.yaml
@@ -14,7 +14,7 @@ lvgl_page_manager:
       friendly_name: "${page_friendly_name}"
 
 external_components:
-  - source: github://stuartparmenter/lvgl-canvas-fx@v0.3.3
+  - source: github://stuartparmenter/lvgl-canvas-fx@v0.4.0
 
 select:
   - platform: template


### PR DESCRIPTION
## Summary

Bump the three external components to their first LVGL 9.5 / ESPHome 2026.4.0 releases, bump `hub75-studio`'s minimum ESPHome version to match, and switch the hub75 matrix controllers to native LVGL byte order (a performance win enabled by the LVGL 9.5 migration).

## Component version bumps

| Component | Old | New | Upstream PR |
|---|---|---|---|
| `lvgl-page-manager` | `v0.2.0` | `v0.3.0` | stuartparmenter/lvgl-page-manager#1 |
| `ddp-esphome` | `v0.7.5` | `v0.8.0` | stuartparmenter/ddp-esphome#21 |
| `lvgl-canvas-fx` | `v0.3.3` | `v0.4.0` | stuartparmenter/lvgl-canvas-fx#3 |

All three new releases port to LVGL 9.5 (`lv_canvas_get_img` → `lv_canvas_get_draw_buf`, `LV_IMG_CF_*` → `LV_COLOR_FORMAT_*`, `LV_COLOR_16_SWAP` removal) and pick up the ESPHome 2026.4.0 automation-layer changes (`synchronous=` `register_action` parameter, templatable `set_time` for `lvgl_page_manager` actions, `socket.require_wake_loop_threadsafe()` removal for `ddp`).

## Minimum ESPHome version

Bumped `packages/common/esphome-version.yaml` from `2026.1.0` to `2026.4.0`. Required by the new component releases — the register_action signatures and the templatable-value plumbing they use don't exist in earlier ESPHome versions.

ESPHome's `min_version` comparison is a lexicographic tuple compare on `(major, minor, patch, extra)`, which (somewhat counterintuitively) sorts `2026.4.0` (empty extra) **before** `2026.4.0b2` (non-empty extra). So setting `min_version: 2026.4.0` correctly accepts users on `2026.4.0b1`/`b2`/… as well as the `2026.4.0` final release and newer — only `2026.3.x` and earlier get rejected.

## Native LVGL byte order on matrix controllers

Set `byte_order: little_endian` on the `lvgl:` block in all four matrix-backed controllers:

- `apollo-automation-m1-rev4`
- `apollo-automation-m1-rev6`
- `adafruit-matrix-portal-s3`
- `esp32-trinity`

The previous `big_endian` default (which was transparent in LVGL 8) now causes LVGL 9.5 to byte-swap the entire render buffer via `lv_draw_sw_rgb565_swap` right before every flush — pure overhead on the frame hot path, since the hub75 matrix driver accepts native RGB565 from ESPHome already. Switching to `little_endian` makes ESPHome stop defining `LV_COLOR_16_SWAP`, which disables the backward-compat swap shim in LVGL's `lv_refr.c` and lets effects land their pixel writes directly in the format the driver expects — ~4k unnecessary byte swaps per flush saved on a 64×64 panel.

## Test plan

- [ ] Build `apollo-automation-m1-rev6.factory.yaml` against ESPHome 2026.4.0+ and flash to an Apollo M-1
- [ ] Confirm bios, clock, clock-dashboard, fx, audio-spectrum, pong, ddp-receiver, and ddp-stream pages all render without warnings
- [ ] Confirm all `lvgl_canvas_fx` effects render correctly (circle, fireworks, fireplace, aurora, audio-spectrum)
- [ ] Confirm wizmote page navigation still works (exercises `lvgl_page_manager.page.show` with a templatable `time`)
- [ ] Confirm DDP stream playback works via the `media_proxy_control` path
- [ ] Smoke-test the other three controllers (`apollo-m1-rev4`, `adafruit-matrix-portal-s3`, `esp32-trinity`) at least `esphome config` level, since they share the same `byte_order` change