### PR TITLE
Add SendSpin music player page

### DIFF
--- a/adafruit-matrix-portal-s3.yaml
+++ b/adafruit-matrix-portal-s3.yaml
@@ -62,7 +62,7 @@ packages:
     - path: packages/common/theme.yaml
 
     # Shared DDP and DDP websocket control config
-    # Note: This is required by "Now Playing" and the "DDP Stream" pages
+    # Note: This is required by "Now Playing", "SendSpin", and the "DDP Stream" pages
     - path: packages/common/ddp.yaml
       vars:
         ddp_port: "4048"

--- a/adafruit-matrix-portal-s3.yaml
+++ b/adafruit-matrix-portal-s3.yaml
@@ -105,6 +105,11 @@ packages:
     #     ha_base_url: "http://homeassistant.local:8123"  # Used to get preview images
     #     media_player_entity: "media_player.your_media_player"
 
+    # SendSpin music player page (album art + track info + progress)
+    # - path: packages/pages/sendspin.yaml
+    #   vars:
+    #     page_friendly_name: "SendSpin"
+
     # Page that uses lvgl-canvas-fx to render various effects (and change which in HA)
     - path: packages/pages/fx.yaml
       vars:

--- a/apollo-automation-m1-rev4.yaml
+++ b/apollo-automation-m1-rev4.yaml
@@ -59,7 +59,7 @@ packages:
     - path: packages/common/theme.yaml
 
     # Shared DDP and DDP websocket control config
-    # Note: This is required by "Now Playing" and the "DDP Stream" pages
+    # Note: This is required by "Now Playing", "SendSpin", and the "DDP Stream" pages
     - path: packages/common/ddp.yaml
       vars:
         ddp_port: "4048"

--- a/apollo-automation-m1-rev4.yaml
+++ b/apollo-automation-m1-rev4.yaml
@@ -102,6 +102,11 @@ packages:
     #     ha_base_url: "http://homeassistant.local:8123"  # Used to get preview images
     #     media_player_entity: "media_player.your_media_player"
 
+    # SendSpin music player page (album art + track info + progress)
+    # - path: packages/pages/sendspin.yaml
+    #   vars:
+    #     page_friendly_name: "SendSpin"
+
     # Page that uses lvgl-canvas-fx to render various effects (and change which in HA)
     - path: packages/pages/fx.yaml
       vars:

--- a/apollo-automation-m1-rev6.yaml
+++ b/apollo-automation-m1-rev6.yaml
@@ -62,7 +62,7 @@ packages:
     - path: packages/common/theme.yaml
 
     # Shared DDP and DDP websocket control config
-    # Note: This is required by "Now Playing" and the "DDP Stream" pages
+    # Note: This is required by "Now Playing", "SendSpin", and the "DDP Stream" pages
     - path: packages/common/ddp.yaml
       vars:
         ddp_port: "4048"

--- a/apollo-automation-m1-rev6.yaml
+++ b/apollo-automation-m1-rev6.yaml
@@ -105,6 +105,11 @@ packages:
     #     ha_base_url: "http://homeassistant.local:8123"  # Used to get preview images
     #     media_player_entity: "media_player.your_media_player"
 
+    # SendSpin music player page (album art + track info + progress)
+    # - path: packages/pages/sendspin.yaml
+    #   vars:
+    #     page_friendly_name: "SendSpin"
+
     # Page that uses lvgl-canvas-fx to render various effects (and change which in HA)
     - path: packages/pages/fx.yaml
       vars:

--- a/packages/common/utils.yaml
+++ b/packages/common/utils.yaml
@@ -122,3 +122,158 @@ text_sensor:
       icon: "mdi:ip-outline"
       entity_category: "diagnostic"
       disabled_by_default: true
+
+# Shared helper: transliterate non-ASCII text (curly quotes, em-dashes,
+# accented Latin-1 letters, ligatures, etc.) into ASCII-friendly glyphs
+# that render in Spleen and other ASCII-only bitmap fonts, then write the
+# result to the given LVGL label widget. Anything left after
+# transliteration that isn't printable ASCII is replaced with a space to
+# avoid font-missing tofu boxes.
+script:
+  - id: normalize_media_text
+    mode: restart
+    parameters:
+      widget: lv_obj_t*
+      text: string
+    then:
+      - lambda: |-
+          auto rep_all = [](std::string &s, const char *from, const char *to) {
+            const size_t flen = std::strlen(from);
+            const size_t tlen = std::strlen(to);
+            if (flen == 0) return;
+            size_t pos = 0;
+            while ((pos = s.find(from, pos)) != std::string::npos) {
+              s.replace(pos, flen, to);
+              pos += tlen;
+            }
+          };
+          std::string s = text;
+          const bool is_ascii = std::all_of(s.begin(), s.end(),
+            [](unsigned char ch){ return ch < 0x80; });
+          if (!is_ascii) {
+            // --- Hyphens / Dashes ---
+            // Normalize everything to ASCII hyphen-minus (U+002D)
+            rep_all(s, "\x2D", "-");          // U+002D HYPHEN-MINUS
+            rep_all(s, "\xE2\x80\x90", "-");  // U+2010 HYPHEN
+            rep_all(s, "\xE2\x80\x91", "-");  // U+2011 NON-BREAKING HYPHEN
+            rep_all(s, "\xE2\x80\x92", "-");  // U+2012 FIGURE DASH
+            rep_all(s, "\xE2\x80\x93", "-");  // U+2013 EN DASH
+            rep_all(s, "\xE2\x80\x94", "-");  // U+2014 EM DASH
+            rep_all(s, "\xE2\x80\x95", "-");  // U+2015 HORIZONTAL BAR
+            rep_all(s, "\xE2\x88\x92", "-");  // U+2212 MINUS SIGN
+            rep_all(s, "\xEF\xBC\x8D", "-");  // U+FF0D FULLWIDTH HYPHEN-MINUS
+            rep_all(s, "\xC2\xAD", "");       // U+00AD SOFT HYPHEN (delete)
+            rep_all(s, "\xE2\x81\x83", "");   // U+2053 SWUNG DASH (delete)
+
+            // --- Quotes / Apostrophes ---
+            // Collapse curly/special quotes into ASCII ' and "
+            rep_all(s, "\xE2\x80\x98", "'");  // U+2018 LEFT SINGLE QUOTATION MARK
+            rep_all(s, "\xE2\x80\x99", "'");  // U+2019 RIGHT SINGLE QUOTATION MARK
+            rep_all(s, "\xE2\x80\x9A", "'");  // U+201A SINGLE LOW-9 QUOTATION MARK
+            rep_all(s, "\xE2\x80\xB2", "'");  // U+2032 PRIME (often used as apostrophe)
+            rep_all(s, "\xE2\x80\x9C", "\""); // U+201C LEFT DOUBLE QUOTATION MARK
+            rep_all(s, "\xE2\x80\x9D", "\""); // U+201D RIGHT DOUBLE QUOTATION MARK
+            rep_all(s, "\xE2\x80\x9E", "\""); // U+201E DOUBLE LOW-9 QUOTATION MARK
+
+            // --- Ellipsis ---
+            rep_all(s, "\xE2\x80\xA6", "..."); // U+2026 HORIZONTAL ELLIPSIS
+
+            // --- Spaces ---
+            // Normalize special spaces to ASCII space
+            rep_all(s, "\xC2\xA0", " ");      // U+00A0 NO-BREAK SPACE
+            rep_all(s, "\xE2\x80\xAF", " ");  // U+202F NARROW NO-BREAK SPACE
+            rep_all(s, "\xE2\x81\x9F", " ");  // U+205F MEDIUM MATHEMATICAL SPACE
+            rep_all(s, "\xE3\x80\x80", " ");  // U+3000 IDEOGRAPHIC SPACE
+
+            // --- Latin-1 Supplement letters (U+00C0–U+00FF) ---
+            // A
+            rep_all(s, "\xC3\x80", "A"); // U+00C0 À
+            rep_all(s, "\xC3\x81", "A"); // U+00C1 Á
+            rep_all(s, "\xC3\x82", "A"); // U+00C2 Â
+            rep_all(s, "\xC3\x83", "A"); // U+00C3 Ã
+            rep_all(s, "\xC3\x84", "A"); // U+00C4 Ä
+            rep_all(s, "\xC3\x85", "A"); // U+00C5 Å
+            rep_all(s, "\xC3\xA0", "a"); // U+00E0 à
+            rep_all(s, "\xC3\xA1", "a"); // U+00E1 á
+            rep_all(s, "\xC3\xA2", "a"); // U+00E2 â
+            rep_all(s, "\xC3\xA3", "a"); // U+00E3 ã
+            rep_all(s, "\xC3\xA4", "a"); // U+00E4 ä
+            rep_all(s, "\xC3\xA5", "a"); // U+00E5 å
+
+            // AE ligature
+            rep_all(s, "\xC3\x86", "AE"); // U+00C6 Æ
+            rep_all(s, "\xC3\xA6", "ae"); // U+00E6 æ
+
+            // C
+            rep_all(s, "\xC3\x87", "C"); // U+00C7 Ç
+            rep_all(s, "\xC3\xA7", "c"); // U+00E7 ç
+
+            // E
+            rep_all(s, "\xC3\x88", "E"); // U+00C8 È
+            rep_all(s, "\xC3\x89", "E"); // U+00C9 É
+            rep_all(s, "\xC3\x8A", "E"); // U+00CA Ê
+            rep_all(s, "\xC3\x8B", "E"); // U+00CB Ë
+            rep_all(s, "\xC3\xA8", "e"); // U+00E8 è
+            rep_all(s, "\xC3\xA9", "e"); // U+00E9 é
+            rep_all(s, "\xC3\xAA", "e"); // U+00EA ê
+            rep_all(s, "\xC3\xAB", "e"); // U+00EB ë
+
+            // I
+            rep_all(s, "\xC3\x8C", "I"); // U+00CC Ì
+            rep_all(s, "\xC3\x8D", "I"); // U+00CD Í
+            rep_all(s, "\xC3\x8E", "I"); // U+00CE Î
+            rep_all(s, "\xC3\x8F", "I"); // U+00CF Ï
+            rep_all(s, "\xC3\xAC", "i"); // U+00EC ì
+            rep_all(s, "\xC3\xAD", "i"); // U+00ED í
+            rep_all(s, "\xC3\xAE", "i"); // U+00EE î
+            rep_all(s, "\xC3\xAF", "i"); // U+00EF ï
+
+            // N
+            rep_all(s, "\xC3\x91", "N"); // U+00D1 Ñ
+            rep_all(s, "\xC3\xB1", "n"); // U+00F1 ñ
+
+            // O
+            rep_all(s, "\xC3\x92", "O"); // U+00D2 Ò
+            rep_all(s, "\xC3\x93", "O"); // U+00D3 Ó
+            rep_all(s, "\xC3\x94", "O"); // U+00D4 Ô
+            rep_all(s, "\xC3\x95", "O"); // U+00D5 Õ
+            rep_all(s, "\xC3\x96", "O"); // U+00D6 Ö
+            rep_all(s, "\xC3\x98", "O"); // U+00D8 Ø
+            rep_all(s, "\xC3\xB2", "o"); // U+00F2 ò
+            rep_all(s, "\xC3\xB3", "o"); // U+00F3 ó
+            rep_all(s, "\xC3\xB4", "o"); // U+00F4 ô
+            rep_all(s, "\xC3\xB5", "o"); // U+00F5 õ
+            rep_all(s, "\xC3\xB6", "o"); // U+00F6 ö
+            rep_all(s, "\xC3\xB8", "o"); // U+00F8 ø
+
+            // U
+            rep_all(s, "\xC3\x99", "U"); // U+00D9 Ù
+            rep_all(s, "\xC3\x9A", "U"); // U+00DA Ú
+            rep_all(s, "\xC3\x9B", "U"); // U+00DB Û
+            rep_all(s, "\xC3\x9C", "U"); // U+00DC Ü
+            rep_all(s, "\xC3\xB9", "u"); // U+00F9 ù
+            rep_all(s, "\xC3\xBA", "u"); // U+00FA ú
+            rep_all(s, "\xC3\xBB", "u"); // U+00FB û
+            rep_all(s, "\xC3\xBC", "u"); // U+00FC ü
+
+            // Y
+            rep_all(s, "\xC3\x9D", "Y"); // U+00DD Ý
+            rep_all(s, "\xC3\xBD", "y"); // U+00FD ý
+            rep_all(s, "\xC3\xBF", "y"); // U+00FF ÿ
+
+            // ß
+            rep_all(s, "\xC3\x9F", "ss"); // U+00DF ß
+
+            // --- Ligatures (Latin Extended but common) ---
+            rep_all(s, "\xC5\x92", "OE"); // U+0152 Œ
+            rep_all(s, "\xC5\x93", "oe"); // U+0153 œ
+          }
+          // Final pass: drop anything that isn't printable ASCII so
+          // un-transliterated glyphs (CJK, emoji, etc.) don't render as
+          // missing-glyph boxes on bitmap fonts.
+          std::string clean;
+          clean.reserve(s.size());
+          for (unsigned char c : s) {
+            clean += (c >= 0x20 && c <= 0x7E) ? (char)c : ' ';
+          }
+          lv_label_set_text((lv_obj_t*)widget, clean.c_str());

--- a/packages/pages/now-playing.yaml
+++ b/packages/pages/now-playing.yaml
@@ -19,149 +19,6 @@ substitutions:
   DEFAULT_ART_SRC: "internal:placeholder/64x64/000000.png"
 
 script:
-  - id: np_set_label_text_normalized_${uid}
-    mode: restart
-    parameters:
-      widget: lv_obj_t*
-      text: string
-      simplify_unicode: bool
-    then:
-      - lambda: |-
-          auto rep_all = [](std::string &s, const char *from, const char *to) {
-            const size_t flen = std::strlen(from);
-            const size_t tlen = std::strlen(to);
-            if (flen == 0) return;
-            size_t pos = 0;
-            while ((pos = s.find(from, pos)) != std::string::npos) {
-              s.replace(pos, flen, to);
-              pos += tlen;
-            }
-          };
-          auto normalize_media_text = [&](std::string s) -> std::string {
-            if (!simplify_unicode) return s;
-            if (std::all_of(s.begin(), s.end(), [](unsigned char ch){ return ch < 0x80; })) return s;
-            // --- Hyphens / Dashes ---
-            // Normalize everything to ASCII hyphen-minus (U+002D)
-            rep_all(s, "\x2D", "-");          // U+002D HYPHEN-MINUS
-            rep_all(s, "\xE2\x80\x90", "-");  // U+2010 HYPHEN
-            rep_all(s, "\xE2\x80\x91", "-");  // U+2011 NON-BREAKING HYPHEN
-            rep_all(s, "\xE2\x80\x92", "-");  // U+2012 FIGURE DASH
-            rep_all(s, "\xE2\x80\x93", "-");  // U+2013 EN DASH
-            rep_all(s, "\xE2\x80\x94", "-");  // U+2014 EM DASH
-            rep_all(s, "\xE2\x80\x95", "-");  // U+2015 HORIZONTAL BAR
-            rep_all(s, "\xE2\x88\x92", "-");  // U+2212 MINUS SIGN
-            rep_all(s, "\xEF\xBC\x8D", "-");  // U+FF0D FULLWIDTH HYPHEN-MINUS
-            rep_all(s, "\xC2\xAD", "");       // U+00AD SOFT HYPHEN (delete)
-            rep_all(s, "\xE2\x81\x83", "");   // U+2053 SWUNG DASH (delete)
-
-            // --- Quotes / Apostrophes ---
-            // Collapse curly/special quotes into ASCII ' and "
-            rep_all(s, "\xE2\x80\x98", "'");  // U+2018 LEFT SINGLE QUOTATION MARK
-            rep_all(s, "\xE2\x80\x99", "'");  // U+2019 RIGHT SINGLE QUOTATION MARK
-            rep_all(s, "\xE2\x80\x9A", "'");  // U+201A SINGLE LOW-9 QUOTATION MARK
-            rep_all(s, "\xE2\x80\xB2", "'");  // U+2032 PRIME (often used as apostrophe)
-            rep_all(s, "\xE2\x80\x9C", "\""); // U+201C LEFT DOUBLE QUOTATION MARK
-            rep_all(s, "\xE2\x80\x9D", "\""); // U+201D RIGHT DOUBLE QUOTATION MARK
-            rep_all(s, "\xE2\x80\x9E", "\""); // U+201E DOUBLE LOW-9 QUOTATION MARK
-
-            // --- Ellipsis ---
-            rep_all(s, "\xE2\x80\xA6", "..."); // U+2026 HORIZONTAL ELLIPSIS
-
-            // --- Spaces ---
-            // Normalize special spaces to ASCII space
-            rep_all(s, "\xC2\xA0", " ");      // U+00A0 NO-BREAK SPACE
-            rep_all(s, "\xE2\x80\xAF", " ");  // U+202F NARROW NO-BREAK SPACE
-            rep_all(s, "\xE2\x81\x9F", " ");  // U+205F MEDIUM MATHEMATICAL SPACE
-            rep_all(s, "\xE3\x80\x80", " ");  // U+3000 IDEOGRAPHIC SPACE
-
-            // --- Latin-1 Supplement letters (U+00C0–U+00FF) ---
-            // A
-            rep_all(s, "\xC3\x80", "A"); // U+00C0 À
-            rep_all(s, "\xC3\x81", "A"); // U+00C1 Á
-            rep_all(s, "\xC3\x82", "A"); // U+00C2 Â
-            rep_all(s, "\xC3\x83", "A"); // U+00C3 Ã
-            rep_all(s, "\xC3\x84", "A"); // U+00C4 Ä
-            rep_all(s, "\xC3\x85", "A"); // U+00C5 Å
-            rep_all(s, "\xC3\xA0", "a"); // U+00E0 à
-            rep_all(s, "\xC3\xA1", "a"); // U+00E1 á
-            rep_all(s, "\xC3\xA2", "a"); // U+00E2 â
-            rep_all(s, "\xC3\xA3", "a"); // U+00E3 ã
-            rep_all(s, "\xC3\xA4", "a"); // U+00E4 ä
-            rep_all(s, "\xC3\xA5", "a"); // U+00E5 å
-
-            // AE ligature
-            rep_all(s, "\xC3\x86", "AE"); // U+00C6 Æ
-            rep_all(s, "\xC3\xA6", "ae"); // U+00E6 æ
-
-            // C
-            rep_all(s, "\xC3\x87", "C"); // U+00C7 Ç
-            rep_all(s, "\xC3\xA7", "c"); // U+00E7 ç
-
-            // E
-            rep_all(s, "\xC3\x88", "E"); // U+00C8 È
-            rep_all(s, "\xC3\x89", "E"); // U+00C9 É
-            rep_all(s, "\xC3\x8A", "E"); // U+00CA Ê
-            rep_all(s, "\xC3\x8B", "E"); // U+00CB Ë
-            rep_all(s, "\xC3\xA8", "e"); // U+00E8 è
-            rep_all(s, "\xC3\xA9", "e"); // U+00E9 é
-            rep_all(s, "\xC3\xAA", "e"); // U+00EA ê
-            rep_all(s, "\xC3\xAB", "e"); // U+00EB ë
-
-            // I
-            rep_all(s, "\xC3\x8C", "I"); // U+00CC Ì
-            rep_all(s, "\xC3\x8D", "I"); // U+00CD Í
-            rep_all(s, "\xC3\x8E", "I"); // U+00CE Î
-            rep_all(s, "\xC3\x8F", "I"); // U+00CF Ï
-            rep_all(s, "\xC3\xAC", "i"); // U+00EC ì
-            rep_all(s, "\xC3\xAD", "i"); // U+00ED í
-            rep_all(s, "\xC3\xAE", "i"); // U+00EE î
-            rep_all(s, "\xC3\xAF", "i"); // U+00EF ï
-
-            // N
-            rep_all(s, "\xC3\x91", "N"); // U+00D1 Ñ
-            rep_all(s, "\xC3\xB1", "n"); // U+00F1 ñ
-
-            // O
-            rep_all(s, "\xC3\x92", "O"); // U+00D2 Ò
-            rep_all(s, "\xC3\x93", "O"); // U+00D3 Ó
-            rep_all(s, "\xC3\x94", "O"); // U+00D4 Ô
-            rep_all(s, "\xC3\x95", "O"); // U+00D5 Õ
-            rep_all(s, "\xC3\x96", "O"); // U+00D6 Ö
-            rep_all(s, "\xC3\x98", "O"); // U+00D8 Ø
-            rep_all(s, "\xC3\xB2", "o"); // U+00F2 ò
-            rep_all(s, "\xC3\xB3", "o"); // U+00F3 ó
-            rep_all(s, "\xC3\xB4", "o"); // U+00F4 ô
-            rep_all(s, "\xC3\xB5", "o"); // U+00F5 õ
-            rep_all(s, "\xC3\xB6", "o"); // U+00F6 ö
-            rep_all(s, "\xC3\xB8", "o"); // U+00F8 ø
-
-            // U
-            rep_all(s, "\xC3\x99", "U"); // U+00D9 Ù
-            rep_all(s, "\xC3\x9A", "U"); // U+00DA Ú
-            rep_all(s, "\xC3\x9B", "U"); // U+00DB Û
-            rep_all(s, "\xC3\x9C", "U"); // U+00DC Ü
-            rep_all(s, "\xC3\xB9", "u"); // U+00F9 ù
-            rep_all(s, "\xC3\xBA", "u"); // U+00FA ú
-            rep_all(s, "\xC3\xBB", "u"); // U+00FB û
-            rep_all(s, "\xC3\xBC", "u"); // U+00FC ü
-
-            // Y
-            rep_all(s, "\xC3\x9D", "Y"); // U+00DD Ý
-            rep_all(s, "\xC3\xBD", "y"); // U+00FD ý
-            rep_all(s, "\xC3\xBF", "y"); // U+00FF ÿ
-
-            // ß
-            rep_all(s, "\xC3\x9F", "ss"); // U+00DF ß
-
-            // --- Ligatures (Latin Extended but common) ---
-            rep_all(s, "\xC5\x92", "OE"); // U+0152 Œ
-            rep_all(s, "\xC5\x93", "oe"); // U+0153 œ
-
-            return s;
-          };
-          std::string out = normalize_media_text(text);
-          lv_label_set_text((lv_obj_t*)widget, out.c_str());
-
   - id: np_set_art_src_resolved_${uid}
     mode: restart
     parameters:
@@ -218,10 +75,9 @@ text_sensor:
     internal: true
     on_value:
       - script.execute:
-          id: np_set_label_text_normalized_${uid}
+          id: normalize_media_text
           widget: !lambda 'return id(title_lbl_${uid});'
           text: !lambda 'return x.c_str();'
-          simplify_unicode: true
 
   - platform: homeassistant
     id: ha_media_artist_${uid}
@@ -230,10 +86,9 @@ text_sensor:
     internal: true
     on_value:
       - script.execute:
-          id: np_set_label_text_normalized_${uid}
+          id: normalize_media_text
           widget: !lambda 'return id(artist_lbl_${uid});'
           text: !lambda 'return x.c_str();'
-          simplify_unicode: true
 
   - platform: homeassistant
     id: ha_media_album_${uid}
@@ -242,10 +97,9 @@ text_sensor:
     internal: true
     on_value:
       - script.execute:
-          id: np_set_label_text_normalized_${uid}
+          id: normalize_media_text
           widget: !lambda 'return id(album_lbl_${uid});'
           text: !lambda 'return x.c_str();'
-          simplify_unicode: true
 
   - platform: homeassistant
     id: ha_entity_picture_${uid}

--- a/packages/pages/sendspin.yaml
+++ b/packages/pages/sendspin.yaml
@@ -6,8 +6,21 @@
 # streamed to the device via the SendSpin ESPHome media_player component.
 # Designed for a single 64x64 panel.
 #
+# Album art is streamed through the shared media proxy over DDP (same path
+# as now-playing.yaml) rather than decoded on-device. This keeps memory
+# pressure low (no JPEG decoder, no raw-image buffer) and lets devices
+# without PSRAM run the page. See Caveats below.
+#
 # Required vars:
 #   page_friendly_name: Name of the page (e.g., SendSpin)
+#
+# Depends on packages/common/ddp.yaml being loaded (provides mp_control).
+#
+# Caveats:
+#   - Requires the sendspin server to populate the `artwork_url` metadata
+#     field. If the server only streams raw image bytes, nothing renders.
+#   - Requires the media proxy host to be able to fetch that URL (public
+#     provider CDNs like i.scdn.co / is1-ssl.mzstatic.com work fine).
 
 lvgl_page_manager:
   pages:
@@ -16,35 +29,15 @@ lvgl_page_manager:
 
 external_components:
   - source: github://kahrendt/esphome@sendspin-dev-snapshot2
-    components: [const, generic_image, sendspin]
+    # generic_image intentionally omitted: its presence would make the
+    # device advertise ARTWORK support in the HELLO handshake and receive
+    # raw image bytes to decode locally. We skip it so the server knows to
+    # hold off, and we pull artwork via DDP through media_proxy_control.
+    components: [const, sendspin]
     refresh: 0s
 
 sendspin:
   id: sendspin_hub
-
-generic_image:
-  - platform: sendspin
-    id: sendspin_cover_art
-    format: jpg
-    type: rgb565
-    resize: 64x64
-    image_source: ALBUM
-    on_image_decoded:
-      - lambda: |-
-          lv_obj_t* img = id(sendspin_album_art);
-          lv_img_set_src(img, id(sendspin_cover_art));
-          lv_img_set_zoom(img, LV_ZOOM_NONE);
-          static lv_anim_t fade_in;
-          lv_anim_init(&fade_in);
-          lv_anim_set_var(&fade_in, img);
-          lv_anim_set_values(&fade_in, 0, 255);
-          lv_anim_set_time(&fade_in, 300);
-          lv_anim_set_exec_cb(&fade_in, [](void* obj, int32_t v) {
-              lv_obj_set_style_img_opa((lv_obj_t*)obj, v, 0);
-          });
-          lv_anim_start(&fade_in);
-    on_image_error:
-      - logger.log: "Failed to decode SendSpin cover art"
 
 media_player:
   - platform: sendspin
@@ -130,17 +123,63 @@ interval:
                         lv_bar_set_value(id(sendspin_progress_bar), pct, LV_ANIM_OFF);
                       }
 
+# ---------------------------------------------------------------------------
+# Album art via shared media proxy / DDP
+# ---------------------------------------------------------------------------
+# Holds the current artwork URL across callback invocations so the c_str()
+# passed to set_src() stays valid.
+globals:
+  - id: sendspin_art_src
+    type: std::string
+    restore_value: no
+    initial_value: '"internal:placeholder/64x64/000000.png"'
+
+# Bind a DDP stream ID to the LVGL canvas that will display the album art.
+ddp_canvas:
+  - id: sendspin_art_stream
+    canvas: sendspin_art_canvas
+    back_buffers: 0
+
+# Extend the shared mp_control (declared in packages/common/ddp.yaml) with
+# an output that feeds our DDP stream. Proxy fetches the URL, rescales to
+# 64x64 rgb565, and streams frames over UDP.
+media_proxy_control:
+  id: mp_control
+  outputs:
+    - id: sendspin_art_output
+      stream: sendspin_art_stream
+      src: "internal:placeholder/64x64/000000.png"
+      loop: false
+      format: rgb565
+
+# Register a metadata callback on the sendspin hub once everything is up.
+# The callback is deferred to the main loop by the hub (see
+# sendspin_hub.cpp:808), so it's safe to touch globals / LVGL / the media
+# proxy from here.
+esphome:
+  on_boot:
+    - priority: -100
+      then:
+        - lambda: |-
+            id(sendspin_hub).add_metadata_callback(
+              [](const auto &m) {
+                if (!m.artwork_url.has_value() || m.artwork_url->empty()) return;
+                const std::string &url = *m.artwork_url;
+                if (url == id(sendspin_art_src)) return;  // URL unchanged, skip
+                id(sendspin_art_src) = url;
+                id(sendspin_art_output).set_src(id(sendspin_art_src).c_str());
+              });
+
 lvgl:
   pages:
     - id: page_sendspin
       bg_color: 0x000000
       scrollbar_mode: "OFF"
       widgets:
-        - image:
-            id: sendspin_album_art
+        - canvas:
+            id: sendspin_art_canvas
             x: 0
             y: 0
-            src: sendspin_cover_art
             width: 64
             height: 64
 
@@ -185,5 +224,6 @@ lvgl:
       on_load:
         then:
           - lambda: |-
+              id(sendspin_art_output).start();
               uint32_t anim_ms = (uint32_t)(11000 - id(sendspin_scroll_speed).state * 1000);
               lv_obj_set_style_anim_time(id(sendspin_now_playing_label), anim_ms, LV_PART_MAIN);

--- a/packages/pages/sendspin.yaml
+++ b/packages/pages/sendspin.yaml
@@ -1,0 +1,189 @@
+# © Copyright 2026 Stuart Parmenter
+# SPDX-License-Identifier: MIT
+
+# SendSpin Music Player Page
+# Displays album art, scrolling track info, and a progress bar for music
+# streamed to the device via the SendSpin ESPHome media_player component.
+# Designed for a single 64x64 panel.
+#
+# Required vars:
+#   page_friendly_name: Name of the page (e.g., SendSpin)
+
+lvgl_page_manager:
+  pages:
+    - page: page_sendspin
+      friendly_name: "${page_friendly_name}"
+
+external_components:
+  - source: github://kahrendt/esphome@sendspin-dev-snapshot2
+    components: [const, generic_image, sendspin]
+    refresh: 0s
+
+sendspin:
+  id: sendspin_hub
+
+generic_image:
+  - platform: sendspin
+    id: sendspin_cover_art
+    format: jpg
+    type: rgb565
+    resize: 64x64
+    image_source: ALBUM
+    on_image_decoded:
+      - lambda: |-
+          lv_obj_t* img = id(sendspin_album_art);
+          lv_img_set_src(img, id(sendspin_cover_art));
+          lv_img_set_zoom(img, LV_ZOOM_NONE);
+          static lv_anim_t fade_in;
+          lv_anim_init(&fade_in);
+          lv_anim_set_var(&fade_in, img);
+          lv_anim_set_values(&fade_in, 0, 255);
+          lv_anim_set_time(&fade_in, 300);
+          lv_anim_set_exec_cb(&fade_in, [](void* obj, int32_t v) {
+              lv_obj_set_style_img_opa((lv_obj_t*)obj, v, 0);
+          });
+          lv_anim_start(&fade_in);
+    on_image_error:
+      - logger.log: "Failed to decode SendSpin cover art"
+
+media_player:
+  - platform: sendspin
+    id: sendspin_media_player
+    name: "SendSpin Player"
+
+text_sensor:
+  - platform: sendspin
+    id: sendspin_track_title
+    type: title
+    on_value:
+      - component.update: sendspin_now_playing_text
+
+  - platform: sendspin
+    id: sendspin_track_artist
+    type: artist
+    on_value:
+      - component.update: sendspin_now_playing_text
+
+  - platform: sendspin
+    id: sendspin_album_title
+    type: album
+
+  - platform: template
+    id: sendspin_now_playing_text
+    lambda: |-
+      std::string text = id(sendspin_track_title).get_state();
+      if (!id(sendspin_track_artist).get_state().empty()) {
+        if (!text.empty()) {
+          text += " - ";
+        }
+        text += id(sendspin_track_artist).get_state();
+      }
+      return text;
+    on_value:
+      - script.execute:
+          id: normalize_media_text
+          widget: !lambda 'return id(sendspin_now_playing_label);'
+          text: !lambda 'return x.c_str();'
+    update_interval: never
+
+sensor:
+  - platform: sendspin
+    type: track_duration
+    id: sendspin_track_duration
+
+number:
+  - platform: template
+    name: "SendSpin Scroll Speed"
+    id: sendspin_scroll_speed
+    icon: "mdi:speedometer"
+    entity_category: config
+    min_value: 1
+    max_value: 10
+    step: 1
+    initial_value: 5
+    optimistic: true
+    restore_value: true
+    on_value:
+      - lambda: |-
+          uint32_t anim_ms = (uint32_t)(11000 - x * 1000);
+          lv_obj_set_style_anim_time(id(sendspin_now_playing_label), anim_ms, LV_PART_MAIN);
+          // Force the running scroll animation to restart with the new speed
+          lv_label_set_long_mode(id(sendspin_now_playing_label), LV_LABEL_LONG_CLIP);
+          lv_label_set_long_mode(id(sendspin_now_playing_label), LV_LABEL_LONG_SCROLL_CIRCULAR);
+
+# Poll track progress while playing and drive the progress bar.
+# Runs regardless of which page is active so the bar is ready on page switch.
+interval:
+  - interval: 0.25s
+    then:
+      - if:
+          condition:
+            - media_player.is_playing: sendspin_media_player
+          then:
+            - sendspin.get_track_progress:
+                then:
+                  - lambda: |-
+                      float duration = id(sendspin_track_duration).state;
+                      if (duration > 0) {
+                        int pct = (int)((x * 100.0f) / duration);
+                        pct = std::max(0, std::min(100, pct));
+                        lv_bar_set_value(id(sendspin_progress_bar), pct, LV_ANIM_OFF);
+                      }
+
+lvgl:
+  pages:
+    - id: page_sendspin
+      bg_color: 0x000000
+      scrollbar_mode: "OFF"
+      widgets:
+        - image:
+            id: sendspin_album_art
+            x: 0
+            y: 0
+            src: sendspin_cover_art
+            width: 64
+            height: 64
+
+        - obj:
+            x: 0
+            y: 52
+            width: 64
+            height: 10
+            bg_color: 0x000000
+            bg_opa: 60%
+            border_width: 0
+            radius: 0
+            scrollbar_mode: "OFF"
+            scrollable: false
+            widgets:
+              - label:
+                  id: sendspin_now_playing_label
+                  x: 0
+                  y: 1
+                  width: 64
+                  height: 8
+                  text: ""
+                  text_color: 0xFFFFFF
+                  text_font: spleen_8
+                  long_mode: SCROLL_CIRCULAR
+
+        - bar:
+            id: sendspin_progress_bar
+            x: 0
+            y: 62
+            width: 64
+            height: 2
+            value: 0
+            min_value: 0
+            max_value: 100
+            bg_color: 0x333333
+            bg_opa: COVER
+            indicator:
+              bg_color: 0xFFFFFF
+              bg_opa: COVER
+
+      on_load:
+        then:
+          - lambda: |-
+              uint32_t anim_ms = (uint32_t)(11000 - id(sendspin_scroll_speed).state * 1000);
+              lv_obj_set_style_anim_time(id(sendspin_now_playing_label), anim_ms, LV_PART_MAIN);


### PR DESCRIPTION
## Summary
- Adds `packages/pages/sendspin.yaml` — a 64×64 LVGL page with album art, a scrolling now-playing label, and a 2px track progress bar, driven by the `sendspin` external component from `kahrendt/esphome@sendspin-dev-snapshot2`.
- Album art is routed through the shared media proxy over DDP (same path `now-playing.yaml` uses for HA's `entity_picture`), not decoded on-device. A boot-time lambda registers a `SendspinHub::add_metadata_callback` that pulls the `artwork_url` out of the metadata message and calls `media_proxy_control`'s `set_src()`.
- Because the page omits any `generic_image: - platform: sendspin`, `preferred_image_formats_` stays empty and the device never advertises `ARTWORK` in the sendspin HELLO (see `sendspin_hub.cpp:216`). Server never streams image bytes; `USE_SENDSPIN_ARTWORK` + JPEG decoder drop out of the binary. Net effect: works on boards without PSRAM.
- Device advertises only `controller@v1` + `metadata@v1` — correctly identifies itself as a display/remote surface, not an audio sink.
- Promotes the Latin-1 / curly-quote / em-dash transliterator out of `now-playing.yaml` into `packages/common/utils.yaml` as a shared `normalize_media_text` script. Both pages now share one implementation, and the shared version adds a final non-printable-ASCII strip so un-transliterated glyphs (CJK, emoji, etc.) no longer render as missing-glyph boxes in Spleen.
- Adds commented-out opt-in entries to all three controller configs, matching the pattern used by `now-playing.yaml`.

## Requirements
- Depends on `packages/common/ddp.yaml` (already loaded by default in all three controller configs — provides `mp_control`).
- Requires the sendspin server to populate `artwork_url` in metadata messages.
- Requires the media proxy host to be able to fetch that URL (public provider CDNs like `i.scdn.co` / `is1-ssl.mzstatic.com` work out of the box).

## Out of scope (intentional)
- WizMote button mappings from the original source config — this repo already has a shared `packages/common/wizmote.yaml`, and the user can configure their own page mappings there.
- Audio playback — `media_source: - platform: sendspin` is the audio-sink platform, which this PR intentionally does not include. The `media_player:` here is the CONTROLLER role (HA-exposed transport control widget), not a speaker.

## Test plan
- [x] Compiles on rev6 with the page enabled.
- [x] Flashed rev6 and verified: page appears in the page manager as "SendSpin", artwork renders via DDP, scrolling label works, progress bar advances, scroll-speed number restarts the animation on change.
- [ ] Now Playing page still works with the shared normalizer (quick regression).
- [ ] rev4 smoke test (no PSRAM) — previously expected to OOM on cover-art decode; with on-device decode removed, should now work.
- [ ] Matrix Portal S3 (2MB quad PSRAM) smoke test.