### PR TITLE
Enable Sendspin page by default on rev6 and portal-s3

### DIFF
--- a/adafruit-matrix-portal-s3.factory.yaml
+++ b/adafruit-matrix-portal-s3.factory.yaml
@@ -89,7 +89,7 @@ packages:
   theme: !include packages/common/theme.yaml
 
   # Shared DDP and DDP websocket control config
-  # Note: This is required by "Now Playing" and the "DDP Stream" pages
+  # Note: This is required by "Now Playing", "Sendspin", and the "DDP Stream" pages
   ddp: !include
     file: packages/common/ddp.yaml
     vars:
@@ -106,6 +106,12 @@ packages:
     file: packages/pages/clock.yaml
     vars:
       page_friendly_name: "Clock"
+
+  # Sendspin music player page (album art + track info + progress)
+  sendspin: !include
+    file: packages/pages/sendspin.yaml
+    vars:
+      page_friendly_name: "Sendspin"
 
   # Page that uses lvgl-canvas-fx to render various effects (and change which in HA)
   fx: !include

--- a/adafruit-matrix-portal-s3.yaml
+++ b/adafruit-matrix-portal-s3.yaml
@@ -62,7 +62,7 @@ packages:
     - path: packages/common/theme.yaml
 
     # Shared DDP and DDP websocket control config
-    # Note: This is required by "Now Playing", "SendSpin", and the "DDP Stream" pages
+    # Note: This is required by "Now Playing", "Sendspin", and the "DDP Stream" pages
     - path: packages/common/ddp.yaml
       vars:
         ddp_port: "4048"
@@ -105,10 +105,10 @@ packages:
     #     ha_base_url: "http://homeassistant.local:8123"  # Used to get preview images
     #     media_player_entity: "media_player.your_media_player"
 
-    # SendSpin music player page (album art + track info + progress)
-    # - path: packages/pages/sendspin.yaml
-    #   vars:
-    #     page_friendly_name: "SendSpin"
+    # Sendspin music player page (album art + track info + progress)
+    - path: packages/pages/sendspin.yaml
+      vars:
+        page_friendly_name: "Sendspin"
 
     # Page that uses lvgl-canvas-fx to render various effects (and change which in HA)
     - path: packages/pages/fx.yaml

--- a/apollo-automation-m1-rev4.factory.yaml
+++ b/apollo-automation-m1-rev4.factory.yaml
@@ -86,7 +86,7 @@ packages:
   theme: !include packages/common/theme.yaml
 
   # Shared DDP and DDP websocket control config
-  # Note: This is required by "Now Playing" and the "DDP Stream" pages
+  # Note: This is required by "Now Playing", "Sendspin", and the "DDP Stream" pages
   ddp: !include
     file: packages/common/ddp.yaml
     vars:
@@ -103,6 +103,12 @@ packages:
     file: packages/pages/clock.yaml
     vars:
       page_friendly_name: "Clock"
+
+  # Sendspin music player page (album art + track info + progress)
+  # sendspin: !include
+  #   file: packages/pages/sendspin.yaml
+  #   vars:
+  #     page_friendly_name: "Sendspin"
 
   # Page that uses lvgl-canvas-fx to render various effects (and change which in HA)
   fx: !include

--- a/apollo-automation-m1-rev6.factory.yaml
+++ b/apollo-automation-m1-rev6.factory.yaml
@@ -89,7 +89,7 @@ packages:
   theme: !include packages/common/theme.yaml
 
   # Shared DDP and DDP websocket control config
-  # Note: This is required by "Now Playing" and the "DDP Stream" pages
+  # Note: This is required by "Now Playing", "Sendspin", and the "DDP Stream" pages
   ddp: !include
     file: packages/common/ddp.yaml
     vars:
@@ -106,6 +106,12 @@ packages:
     file: packages/pages/clock.yaml
     vars:
       page_friendly_name: "Clock"
+
+  # Sendspin music player page (album art + track info + progress)
+  sendspin: !include
+    file: packages/pages/sendspin.yaml
+    vars:
+      page_friendly_name: "Sendspin"
 
   # Page that uses lvgl-canvas-fx to render various effects (and change which in HA)
   fx: !include

--- a/apollo-automation-m1-rev6.yaml
+++ b/apollo-automation-m1-rev6.yaml
@@ -62,7 +62,7 @@ packages:
     - path: packages/common/theme.yaml
 
     # Shared DDP and DDP websocket control config
-    # Note: This is required by "Now Playing", "SendSpin", and the "DDP Stream" pages
+    # Note: This is required by "Now Playing", "Sendspin", and the "DDP Stream" pages
     - path: packages/common/ddp.yaml
       vars:
         ddp_port: "4048"
@@ -105,10 +105,10 @@ packages:
     #     ha_base_url: "http://homeassistant.local:8123"  # Used to get preview images
     #     media_player_entity: "media_player.your_media_player"
 
-    # SendSpin music player page (album art + track info + progress)
-    # - path: packages/pages/sendspin.yaml
-    #   vars:
-    #     page_friendly_name: "SendSpin"
+    # Sendspin music player page (album art + track info + progress)
+    - path: packages/pages/sendspin.yaml
+      vars:
+        page_friendly_name: "Sendspin"
 
     # Page that uses lvgl-canvas-fx to render various effects (and change which in HA)
     - path: packages/pages/fx.yaml


### PR DESCRIPTION
## Summary
- Uncomment the Sendspin page include in `apollo-automation-m1-rev6.yaml` and `adafruit-matrix-portal-s3.yaml` so it's on by default in the adopted dashboard config.
- Add a matching `sendspin: !include ...` entry to the rev6 and portal-s3 factory yamls so pre-adoption (freshly-flashed) and post-adoption page sets match.
- Add an opt-in (commented-out) Sendspin entry to `apollo-automation-m1-rev4.factory.yaml` to mirror the rev4 dashboard's opt-in policy.
- Normalize casing: "SendSpin" → "Sendspin" across the touched files, and update the `ddp.yaml` include comment to list Sendspin alongside Now Playing / DDP Stream as a consumer.

## Test plan
- [ ] `esphome config apollo-automation-m1-rev6.yaml` compiles clean and the Sendspin page is present in the package graph.
- [ ] `esphome config apollo-automation-m1-rev6.factory.yaml` compiles clean on a fresh build.
- [ ] Same two checks for `adafruit-matrix-portal-s3.{yaml,factory.yaml}`.
- [ ] `esphome config apollo-automation-m1-rev4.factory.yaml` still compiles (no change to active page set, just a new comment block).
- [ ] Flash a rev6 factory image, confirm Sendspin page shows up in LVGL page rotation before adoption; confirm it remains after adoption.