### PR TITLE
Remove max-parallel from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      max-parallel: 3
       matrix:
         #### Modify below here to match your project ####
         file:


### PR DESCRIPTION
## Summary
- Drops `max-parallel: 3` from the CI matrix in `.github/workflows/ci.yml`.
- After the recent Blacksmith migration (#88), the 3-at-a-time cap is no longer needed — all 9 matrix jobs (3 boards × 3 ESPHome versions) can run concurrently.
- The top-level `concurrency` block still cancels superseded runs on the same ref, so rapid pushes won't pile up.

## Test plan
- [ ] CI workflow runs on this PR with all 9 matrix jobs in parallel and passes.