### PR TITLE
Update stuartparmenter refs to pavlov-net; bump README ESPHome version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HUB75 Studio
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![ESPHome](https://img.shields.io/badge/ESPHome-2025.12-blue)](https://esphome.io/)
+[![ESPHome](https://img.shields.io/badge/ESPHome-2026.4-blue)](https://esphome.io/)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue)](https://www.python.org/)
 
 **Transform your HUB75 LED matrix into a smart display for Home Assistant.**
@@ -39,7 +39,7 @@ Built on **ESPHome** with **LVGL** for smooth graphics, everything integrates se
 
 **For Building from Source (Optional):**
 - **Python 3.11+** required for ESPHome toolchain
-- **ESPHome 2025.12.x** with ESP‑IDF framework (Arduino not supported)
+- **ESPHome 2026.4.x** with ESP‑IDF framework (Arduino not supported)
 - **Home Assistant** for full integration features
 
 **For Using Prebuilt Firmware:**
@@ -77,20 +77,20 @@ Built on **ESPHome** with **LVGL** for smooth graphics, everything integrates se
 - Built on ESP‑IDF with LVGL for smooth graphics
 - Reproducible builds with lockfiles
 
-📖 **[See all 15+ pages with detailed configurations →](https://github.com/stuartparmenter/hub75-studio/wiki/Pages-and-Applications)**
+📖 **[See all 15+ pages with detailed configurations →](https://github.com/pavlov-net/hub75-studio/wiki/Pages-and-Applications)**
 
 ---
 
 ## Getting Started
 
 **Quick Installation (Web Flasher)**
-1. Visit **[HUB75 Studio Web Installer](https://stuartparmenter.github.io/hub75-studio/)**
+1. Visit **[HUB75 Studio Web Installer](https://pavlov-net.github.io/hub75-studio/)**
 2. Connect your device via USB and flash firmware
 3. Configure Wi‑Fi and adopt in Home Assistant
 
-📖 **[View detailed installation guide →](https://github.com/stuartparmenter/hub75-studio/wiki/Installation)**
+📖 **[View detailed installation guide →](https://github.com/pavlov-net/hub75-studio/wiki/Installation)**
 
-> **Alternative**: Download prebuilt firmware from [Releases](https://github.com/stuartparmenter/hub75-studio/releases) and flash via [web.esphome.io](https://web.esphome.io/)
+> **Alternative**: Download prebuilt firmware from [Releases](https://github.com/pavlov-net/hub75-studio/releases) and flash via [web.esphome.io](https://web.esphome.io/)
 
 ---
 
@@ -104,7 +104,7 @@ Customize your device by editing its YAML configuration in ESPHome. Common custo
 - Device‑specific toggles for pages/effects
 - WizMote remote control setup
 
-📖 **[View detailed customization guide (including WizMote setup) →](https://github.com/stuartparmenter/hub75-studio/wiki/Customization)**
+📖 **[View detailed customization guide (including WizMote setup) →](https://github.com/pavlov-net/hub75-studio/wiki/Customization)**
 
 > Keep personal entity IDs and secrets in your local device config inside ESPHome; they're **not** tracked in this repo.
 
@@ -132,9 +132,9 @@ docker run --rm -it -v "$PWD":/config esphome/esphome run apollo-automation-m1-r
 ---
 
 ## External Components
-- **DDP Stream + WebSocket Control**: [`stuartparmenter/lvgl-ddp-stream`](https://github.com/stuartparmenter/lvgl-ddp-stream)
-- **LVGL Canvas Effects**: [`stuartparmenter/lvgl-canvas-fx`](https://github.com/stuartparmenter/lvgl-canvas-fx)
-- **Page Manager**: [`stuartparmenter/lvgl-page-manager`](https://github.com/stuartparmenter/lvgl-page-manager)
+- **DDP Stream + WebSocket Control**: [`pavlov-net/lvgl-ddp-stream`](https://github.com/pavlov-net/lvgl-ddp-stream)
+- **LVGL Canvas Effects**: [`pavlov-net/lvgl-canvas-fx`](https://github.com/pavlov-net/lvgl-canvas-fx)
+- **Page Manager**: [`pavlov-net/lvgl-page-manager`](https://github.com/pavlov-net/lvgl-page-manager)
 
 > For reproducible builds, prefer **tags** or **commit SHAs** rather than a moving branch.
 
@@ -171,7 +171,7 @@ hub75-studio/
 - **USB permissions (Linux):** Add user to dialout/plugdev or use `udev` rules
 - **Blank display:** Verify you selected the correct controller revision
 
-📖 **[View complete troubleshooting guide →](https://github.com/stuartparmenter/hub75-studio/wiki/Troubleshooting)**
+📖 **[View complete troubleshooting guide →](https://github.com/pavlov-net/hub75-studio/wiki/Troubleshooting)**
 
 ---
 

--- a/adafruit-matrix-portal-s3.factory.yaml
+++ b/adafruit-matrix-portal-s3.factory.yaml
@@ -20,7 +20,7 @@ esphome:
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
   project:
-    name: stuartparmenter.hub75-studio
+    name: pavlov-net.hub75-studio
     version: dev # This will be replaced by the github workflows with the `release` version
 
 logger:
@@ -43,7 +43,7 @@ web_server:
 # In this case it is the core yaml file that does not contain the extra things
 # that are provided by this factory yaml file as the user does not need these once adopted.
 dashboard_import:
-  package_import_url: github://stuartparmenter/hub75-studio/adafruit-matrix-portal-s3.yaml@main
+  package_import_url: github://pavlov-net/hub75-studio/adafruit-matrix-portal-s3.yaml@main
   import_full_config: true
 
 # Sets up Bluetooth LE (Only on ESP32) to allow the user
@@ -65,7 +65,7 @@ ota:
 update:
   - platform: http_request
     name: Firmware
-    source: https://github.com/stuartparmenter/hub75-studio/releases/latest/download/adafruit-matrix-portal-s3.manifest.json
+    source: https://github.com/pavlov-net/hub75-studio/releases/latest/download/adafruit-matrix-portal-s3.manifest.json
 
 packages:
   # Sets minimum supported ESPHome version

--- a/adafruit-matrix-portal-s3.yaml
+++ b/adafruit-matrix-portal-s3.yaml
@@ -38,7 +38,7 @@ web_server:
 
 packages:
   remote_package_files:
-    url: https://github.com/stuartparmenter/hub75-studio
+    url: https://github.com/pavlov-net/hub75-studio
     ref: main
     refresh: 0s
     files:

--- a/apollo-automation-m1-rev4.factory.yaml
+++ b/apollo-automation-m1-rev4.factory.yaml
@@ -20,7 +20,7 @@ esphome:
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
   project:
-    name: stuartparmenter.hub75-studio
+    name: pavlov-net.hub75-studio
     version: dev # This will be replaced by the github workflows with the `release` version
 
 logger:
@@ -40,7 +40,7 @@ captive_portal:
 # In this case it is the core yaml file that does not contain the extra things
 # that are provided by this factory yaml file as the user does not need these once adopted.
 dashboard_import:
-  package_import_url: github://stuartparmenter/hub75-studio/apollo-automation-m1-rev4.yaml@main
+  package_import_url: github://pavlov-net/hub75-studio/apollo-automation-m1-rev4.yaml@main
   import_full_config: true
 
 # Sets up Bluetooth LE (Only on ESP32) to allow the user
@@ -62,7 +62,7 @@ ota:
 update:
   - platform: http_request
     name: Firmware
-    source: https://github.com/stuartparmenter/hub75-studio/releases/latest/download/apollo-automation-m1-rev4.manifest.json
+    source: https://github.com/pavlov-net/hub75-studio/releases/latest/download/apollo-automation-m1-rev4.manifest.json
 
 packages:
   # Sets minimum supported ESPHome version

--- a/apollo-automation-m1-rev4.yaml
+++ b/apollo-automation-m1-rev4.yaml
@@ -35,7 +35,7 @@ captive_portal:
 
 packages:
   remote_package_files:
-    url: https://github.com/stuartparmenter/hub75-studio
+    url: https://github.com/pavlov-net/hub75-studio
     ref: main
     refresh: 0s
     files:

--- a/apollo-automation-m1-rev6.factory.yaml
+++ b/apollo-automation-m1-rev6.factory.yaml
@@ -20,7 +20,7 @@ esphome:
   friendly_name: "${friendly_name}"
   name_add_mac_suffix: true
   project:
-    name: stuartparmenter.hub75-studio
+    name: pavlov-net.hub75-studio
     version: dev # This will be replaced by the github workflows with the `release` version
 
 logger:
@@ -43,7 +43,7 @@ web_server:
 # In this case it is the core yaml file that does not contain the extra things
 # that are provided by this factory yaml file as the user does not need these once adopted.
 dashboard_import:
-  package_import_url: github://stuartparmenter/hub75-studio/apollo-automation-m1-rev6.yaml@main
+  package_import_url: github://pavlov-net/hub75-studio/apollo-automation-m1-rev6.yaml@main
   import_full_config: true
 
 # Sets up Bluetooth LE (Only on ESP32) to allow the user
@@ -65,7 +65,7 @@ ota:
 update:
   - platform: http_request
     name: Firmware
-    source: https://github.com/stuartparmenter/hub75-studio/releases/latest/download/apollo-automation-m1-rev6.manifest.json
+    source: https://github.com/pavlov-net/hub75-studio/releases/latest/download/apollo-automation-m1-rev6.manifest.json
 
 packages:
   # Sets minimum supported ESPHome version

--- a/apollo-automation-m1-rev6.yaml
+++ b/apollo-automation-m1-rev6.yaml
@@ -38,7 +38,7 @@ web_server:
 
 packages:
   remote_package_files:
-    url: https://github.com/stuartparmenter/hub75-studio
+    url: https://github.com/pavlov-net/hub75-studio
     ref: main
     refresh: 0s
     files:

--- a/packages/common/ddp.yaml
+++ b/packages/common/ddp.yaml
@@ -11,7 +11,7 @@
 #   device_id: Device ID for WebSocket identification
 
 external_components:
-  - source: github://stuartparmenter/ddp-esphome@v0.8.0
+  - source: github://pavlov-net/ddp-esphome@v0.8.0
 
 # DDP Canvas Binding
 ddp:

--- a/packages/common/utils.yaml
+++ b/packages/common/utils.yaml
@@ -7,7 +7,7 @@ time:
     id: ha_time
 
 external_components:
-  - source: github://stuartparmenter/lvgl-page-manager@v0.3.0
+  - source: github://pavlov-net/lvgl-page-manager@v0.3.0
     components: [lvgl_page_manager]
 
 lvgl_page_manager:

--- a/packages/pages/audio-spectrum.yaml
+++ b/packages/pages/audio-spectrum.yaml
@@ -14,7 +14,7 @@ lvgl_page_manager:
       friendly_name: "${page_friendly_name}"
 
 external_components:
-  - source: github://stuartparmenter/lvgl-canvas-fx@v0.4.0
+  - source: github://pavlov-net/lvgl-canvas-fx@v0.4.0
 
 # ---- Microphone Configuration ----
 # Hardware: I²S digital microphone

--- a/packages/pages/clock-dashboard.yaml
+++ b/packages/pages/clock-dashboard.yaml
@@ -45,7 +45,7 @@ esphome:
 
 # --- Weather icon fonts (icons only; all text uses Spleen from styles.yaml) ---
 font:
-  - file: "https://github.com/stuartparmenter/hub75-studio/raw/refs/heads/main/fonts/materialdesignicons-webfont.ttf"
+  - file: "https://github.com/pavlov-net/hub75-studio/raw/refs/heads/main/fonts/materialdesignicons-webfont.ttf"
     id: mdi_26
     size: 26
     glyphs: [
@@ -58,7 +58,7 @@ font:
       "\U000F0594",  # clear-night
       "\U000F0598"   # snowy
     ]
-  - file: "https://github.com/stuartparmenter/hub75-studio/raw/refs/heads/main/fonts/materialdesignicons-webfont.ttf"
+  - file: "https://github.com/pavlov-net/hub75-studio/raw/refs/heads/main/fonts/materialdesignicons-webfont.ttf"
     id: mdi_12
     size: 12
     glyphs: [

--- a/packages/pages/fx.yaml
+++ b/packages/pages/fx.yaml
@@ -14,7 +14,7 @@ lvgl_page_manager:
       friendly_name: "${page_friendly_name}"
 
 external_components:
-  - source: github://stuartparmenter/lvgl-canvas-fx@v0.4.0
+  - source: github://pavlov-net/lvgl-canvas-fx@v0.4.0
 
 select:
   - platform: template


### PR DESCRIPTION
## Summary
Following the transfer of this repo and the `lvgl-canvas-fx`, `ddp-esphome`, and `lvgl-page-manager` external components to the `pavlov-net` organization, this PR updates all `stuartparmenter/*` references to `pavlov-net/*`.

- **URL updates** across `*.yaml`, `*.factory.yaml`, `packages/**`, and `README.md`:
  - `github.com/stuartparmenter/hub75-studio` → `github.com/pavlov-net/hub75-studio`
  - `github://stuartparmenter/{ddp-esphome,lvgl-canvas-fx,lvgl-page-manager}` → `github://pavlov-net/...`
  - `stuartparmenter.github.io/hub75-studio/` → `pavlov-net.github.io/hub75-studio/`
- **Factory YAML ESPHome project identifier**: `name: stuartparmenter.hub75-studio` → `name: pavlov-net.hub75-studio` in all three `*.factory.yaml` files. Note this changes the project identity string that ESPHome Dashboard uses to track adopted devices.
- **README ESPHome version** (was out of sync with `packages/common/esphome-version.yaml` which already pins `min_version: 2026.4.0`):
  - Badge: `ESPHome-2025.12` → `ESPHome-2026.4`
  - Requirements line: `ESPHome 2025.12.x` → `ESPHome 2026.4.x`

## Notes
- `media-proxy` (still on `stuartparmenter/`) is intentionally left untouched. The `media_proxy_control` occurrences in the YAML are local ESPHome component identifiers, not repo URLs.
- `README.md` line 135 previously said `stuartparmenter/lvgl-ddp-stream` — the canonical repo was renamed to `ddp-esphome` some time ago, and `packages/common/ddp.yaml` already uses the `ddp-esphome` name. This PR keeps the README display text as `lvgl-ddp-stream` (repointed to `pavlov-net/lvgl-ddp-stream`, which should continue to redirect via GitHub's rename history). A follow-up to normalize the README label to `ddp-esphome` would be reasonable cleanup.

## Test plan
- [ ] CI builds all three devices against stable/beta/dev ESPHome.
- [ ] Manually confirm the `dashboard_import` URL in each factory YAML resolves.
- [ ] Confirm the release manifest URL in each factory YAML resolves against the next release.