### PR TITLE
Port label scroll speed to LVGL 9 anim API

### DIFF
--- a/packages/pages/now-playing.yaml
+++ b/packages/pages/now-playing.yaml
@@ -361,6 +361,6 @@ lvgl:
           - lambda: |-
               id(output_art_${uid}).start();
           - lambda: |-
-              lv_obj_set_style_anim_speed(id(title_lbl_${uid}), 7, LV_PART_MAIN);
-              lv_obj_set_style_anim_speed(id(artist_lbl_${uid}), 12, LV_PART_MAIN);
-              lv_obj_set_style_anim_speed(id(album_lbl_${uid}), 8, LV_PART_MAIN);
+              lv_obj_set_style_anim_duration(id(title_lbl_${uid}), lv_anim_speed(7), LV_PART_MAIN);
+              lv_obj_set_style_anim_duration(id(artist_lbl_${uid}), lv_anim_speed(12), LV_PART_MAIN);
+              lv_obj_set_style_anim_duration(id(album_lbl_${uid}), lv_anim_speed(8), LV_PART_MAIN);


### PR DESCRIPTION
## Summary
- `lv_obj_set_style_anim_speed` was removed in LVGL 9 and has **no alias** in `lv_api_map_v8.h`, so the now-playing page failed to compile after the ESPHome 2026.4 / LVGL 9.5 bump in #79.
- Replaced the three calls with `lv_obj_set_style_anim_duration(obj, lv_anim_speed(N), LV_PART_MAIN)`. The `lv_anim_speed()` helper encodes the px/sec value into a sentinel integer; the label scroll code unwraps it via `lv_anim_resolve_speed()` at animation start, so the visual feel is unchanged.

## Scope
Other raw LVGL symbols in the repo were audited and are all either unchanged in v9 or still covered by the compat shims shipped with LVGL 9.5 — so no further YAML changes are needed for this upgrade:

| Symbol | v9 status | Handled via |
|---|---|---|
| `lv_obj_set_style_anim_time` (sendspin.yaml) | renamed | `lv_api_map_v8.h` alias |
| `lv_obj_clear_flag` (multiple) | renamed | `lv_api_map_v8.h` alias |
| `LV_LABEL_LONG_CLIP`, `LV_LABEL_LONG_SCROLL_CIRCULAR` (sendspin.yaml) | renamed | `lv_api_map_v9_1.h` alias |
| `lv_bar_set_value`, `lv_label_set_text`, `lv_obj_add_flag`, `lv_obj_set_pos`, `lv_color_hex`, `LV_ANIM_OFF`, `LV_OBJ_FLAG_HIDDEN`, `LV_PART_MAIN`, `lv_label_set_long_mode` | unchanged | — |

## Test plan
- [ ] CI build matrix passes (apollo-m1-rev4/rev6, portal-s3, trinity all include now-playing)
- [ ] Title/artist/album marquees on the Now Playing page scroll at visibly different speeds, matching pre-upgrade behavior