### PR TITLE
Silence GPIO0 strapping pin warning on Apollo M-1 boot button

### DIFF
--- a/packages/controllers/apollo-automation-m1-rev4.yaml
+++ b/packages/controllers/apollo-automation-m1-rev4.yaml
@@ -36,13 +36,16 @@ display:
     auto_clear_enabled: false
     update_interval: never
 
-# Boot button (GPIO0) as power toggle
+# Boot button (GPIO0) as power toggle.
+# GPIO0 is a strapping pin; safe to use as an input button after boot,
+# so suppress the build-time strapping warning for this intentional use.
 binary_sensor:
   - platform: gpio
     id: power_button
     internal: true
     pin:
       number: GPIO0
+      ignore_strapping_warning: true
       mode:
         input: true
         pullup: true

--- a/packages/controllers/apollo-automation-m1-rev6.yaml
+++ b/packages/controllers/apollo-automation-m1-rev6.yaml
@@ -80,13 +80,16 @@ switch:
     turn_off_action:
       - microphone.mute: m1_mic
 
-# Boot button (GPIO0) as power toggle
+# Boot button (GPIO0) as power toggle.
+# GPIO0 is an ESP32-S3 strapping pin; safe to use as an input button after boot,
+# so suppress the build-time strapping warning for this intentional use.
 binary_sensor:
   - platform: gpio
     id: power_button
     internal: true
     pin:
       number: GPIO0
+      ignore_strapping_warning: true
       mode:
         input: true
         pullup: true


### PR DESCRIPTION
## Summary
- Adds `ignore_strapping_warning: true` to the Apollo M-1 rev4 and rev6 boot-button (`GPIO0`) `binary_sensor` pin configs.
- GPIO0 is a strapping pin on ESP32 / ESP32-S3, but it's the dedicated boot button on the M-1 — using it as an input after boot is intentional and safe. The warning is purely informational, so this just quiets the build log without changing any runtime behavior.

## Test plan
- [x] Compile the rev6 device YAML — GPIO0 strapping warning no longer appears.
- [x] Boot button still toggles the `power` switch as before.
- [ ] Same checks on rev4 (no rev4 hardware on hand, but the change is identical to rev6).