### PR TITLE
Fix panel_height substitution typo for non-square panels

### DIFF
--- a/adafruit-matrix-portal-s3.factory.yaml
+++ b/adafruit-matrix-portal-s3.factory.yaml
@@ -76,7 +76,7 @@ packages:
     file: packages/controllers/adafruit-matrix-portal-s3.yaml
     vars:
       panel_width: ${display_panel_width}
-      panel_height: ${display_panel_width}
+      panel_height: ${display_panel_height}
       layout: ${display_layout}
       layout_rows: ${display_layout_rows}
       layout_cols: ${display_layout_cols}

--- a/adafruit-matrix-portal-s3.yaml
+++ b/adafruit-matrix-portal-s3.yaml
@@ -49,7 +49,7 @@ packages:
     - path: packages/controllers/adafruit-matrix-portal-s3.yaml
       vars:
         panel_width: ${display_panel_width}
-        panel_height: ${display_panel_width}
+        panel_height: ${display_panel_height}
         layout: ${display_layout}
         layout_rows: ${display_layout_rows}
         layout_cols: ${display_layout_cols}

--- a/apollo-automation-m1-rev4.factory.yaml
+++ b/apollo-automation-m1-rev4.factory.yaml
@@ -73,7 +73,7 @@ packages:
     file: packages/controllers/apollo-automation-m1-rev4.yaml
     vars:
       panel_width: ${display_panel_width}
-      panel_height: ${display_panel_width}
+      panel_height: ${display_panel_height}
       layout: ${display_layout}
       layout_rows: ${display_layout_rows}
       layout_cols: ${display_layout_cols}

--- a/apollo-automation-m1-rev4.yaml
+++ b/apollo-automation-m1-rev4.yaml
@@ -46,7 +46,7 @@ packages:
     - path: packages/controllers/apollo-automation-m1-rev4.yaml
       vars:
         panel_width: ${display_panel_width}
-        panel_height: ${display_panel_width}
+        panel_height: ${display_panel_height}
         layout: ${display_layout}
         layout_rows: ${display_layout_rows}
         layout_cols: ${display_layout_cols}

--- a/apollo-automation-m1-rev6.factory.yaml
+++ b/apollo-automation-m1-rev6.factory.yaml
@@ -76,7 +76,7 @@ packages:
     file: packages/controllers/apollo-automation-m1-rev6.yaml
     vars:
       panel_width: ${display_panel_width}
-      panel_height: ${display_panel_width}
+      panel_height: ${display_panel_height}
       layout: ${display_layout}
       layout_rows: ${display_layout_rows}
       layout_cols: ${display_layout_cols}

--- a/apollo-automation-m1-rev6.yaml
+++ b/apollo-automation-m1-rev6.yaml
@@ -49,7 +49,7 @@ packages:
     - path: packages/controllers/apollo-automation-m1-rev6.yaml
       vars:
         panel_width: ${display_panel_width}
-        panel_height: ${display_panel_width}
+        panel_height: ${display_panel_height}
         layout: ${display_layout}
         layout_rows: ${display_layout_rows}
         layout_cols: ${display_layout_cols}


### PR DESCRIPTION
## Summary
- All six top-level board YAMLs were forwarding `panel_height: ${display_panel_width}` into the controller `!include vars:` block, so `display_panel_height` was silently dropped and the hub75 driver always saw a square panel.
- Invisible on the shipped 64×64 examples (where width == height) but breaks any non-square panel: e.g. two stacked 128×64 tiles configured for a 128×128 layout, where the driver receives `panel_height=128` and outputs duplicated halves on each panel.
- One-line fix per file: `display_panel_width` → `display_panel_height` on the `panel_height:` line.

Reported in #103.

## Test plan
- [ ] Default 64×64 example builds (`apollo-automation-m1-rev6.yaml`, `adafruit-matrix-portal-s3.yaml`) still compile unchanged — substituted value is identical (64).
- [ ] User in #103 confirms two stacked 128×64 panels render a single 128×128 image with `display_panel_width: 128`, `display_panel_height: 64`, `display_layout_rows: 2`, `display_layout: BOTTOM_LEFT_UP`.